### PR TITLE
Improved Null Safety Handling

### DIFF
--- a/lib/social_share.dart
+++ b/lib/social_share.dart
@@ -113,9 +113,9 @@ class SocialShare {
     Map<String, dynamic> args;
     String modifiedUrl;
     if (Platform.isAndroid) {
-      modifiedUrl = Uri.parse(url!).toString().replaceAll('#', "%23");
+      modifiedUrl = Uri.parse(url ?? '').toString().replaceAll('#', "%23");
     } else {
-      modifiedUrl = Uri.parse(url!).toString();
+      modifiedUrl = Uri.parse(url ?? '').toString();
     }
     if (hashtags != null && hashtags.isNotEmpty) {
       String tags = "";
@@ -125,15 +125,13 @@ class SocialShare {
       args = <String, dynamic>{
         "captionText": captionText + "\n" + tags.toString(),
         "url": modifiedUrl,
-        "trailingText":
-            (trailingText == null || trailingText.isEmpty) ? "" : trailingText
+        "trailingText": trailingText ?? ''
       };
     } else {
       args = <String, dynamic>{
         "captionText": captionText + " ",
         "url": modifiedUrl,
-        "trailingText":
-            (trailingText == null || trailingText.isEmpty) ? "" : trailingText
+        "trailingText": trailingText ?? ''
       };
     }
     final String? version = await _channel.invokeMethod('shareTwitter', args);
@@ -157,7 +155,7 @@ class SocialShare {
       }
     } else if (Platform.isAndroid) {
       args = <String, dynamic>{
-        "message": message + url! + trailingText!,
+        "message": message + (url ?? '') + (trailingText ?? ''),
       };
     }
     final String? version = await _channel.invokeMethod('shareSms', args);


### PR DESCRIPTION
Improves the Null Safety Handling of shareSMS and shareTwitter.

Previously, values that could possibly be null were set to use the ! operator. This would cause a null error to be thrown because the values could be null.

In its place, I used the ?? operator instead to set the value to the empty string instead.