### PR TITLE
Declare package visibility needs.

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="com.shekarmudaliyar.social_share">
+    <queries>
+        <package android:name="com.instagram.android" />
+        <package android:name="com.facebook.katana" />
+        <package android:name="com.twitter.android" />
+        <package android:name="com.whatsapp" />
+        <package android:name="org.telegram.messenger" />
+    </queries>
     <meta-data android:name="flutterEmbedding" android:value="2"/>
 </manifest>


### PR DESCRIPTION
According to [Google](https://developer.android.com/training/package-visibility/declaring):

> As you create your app, it's important to consider the set of other installed apps on the device that your app intends to access. If your app targets Android 11 (API level 30) or higher, the system makes [some apps visible to your app automatically](https://developer.android.com/training/package-visibility/automatic), but it filters out other apps by default.
> 
> If your app targets Android 11 or higher and needs to interact with apps other than the ones that are [visible automatically](https://developer.android.com/training/package-visibility/automatic), add the [\<queries\>](https://developer.android.com/guide/topics/manifest/queries-element) element in your app's manifest file.

This PR addresses this issue by specifying which packages to query in the `AndroidManifest` file, so the `checkInstalledAppsForShare` function can work properly.

This solves https://github.com/ShekarMudaliyar/social_share/issues/81