### PR TITLE
Fix fb story share and optional sticker

### DIFF
--- a/android/src/main/kotlin/com/shekarmudaliyar/social_share/SocialSharePlugin.kt
+++ b/android/src/main/kotlin/com/shekarmudaliyar/social_share/SocialSharePlugin.kt
@@ -78,9 +78,10 @@ class SocialSharePlugin:FlutterPlugin, MethodCallHandler, ActivityAware {
             intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             
+            var stickerImage: Uri? = null
             if (stickerImagePath!=null) {
                 val file =  File(activeContext!!.cacheDir,stickerImagePath)
-                val stickerImage = FileProvider.getUriForFile(activeContext!!, activeContext!!.applicationContext.packageName + ".com.shekarmudaliyar.social_share", file)
+                stickerImage = FileProvider.getUriForFile(activeContext!!, activeContext!!.applicationContext.packageName + ".com.shekarmudaliyar.social_share", file)
                 intent.putExtra("interactive_asset_uri", stickerImage)
             }
 

--- a/android/src/main/kotlin/com/shekarmudaliyar/social_share/SocialSharePlugin.kt
+++ b/android/src/main/kotlin/com/shekarmudaliyar/social_share/SocialSharePlugin.kt
@@ -107,8 +107,13 @@ class SocialSharePlugin:FlutterPlugin, MethodCallHandler, ActivityAware {
             intent.putExtra("content_url", attributionURL)
             intent.putExtra("top_background_color", backgroundTopColor)
             intent.putExtra("bottom_background_color", backgroundBottomColor)
+            
+            // if stickerImage need to grantUriPermission
+            if (stickerImage!=null) {
+                activity!!.grantUriPermission(appName, stickerImage, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+
             // Instantiate activity and verify it will resolve implicit intent
-            activity!!.grantUriPermission(appName, stickerImageFile, Intent.FLAG_GRANT_READ_URI_PERMISSION)
             if (activity!!.packageManager.resolveActivity(intent, 0) != null) {
                 activeContext!!.startActivity(intent)
                 result.success("success")

--- a/android/src/main/kotlin/com/shekarmudaliyar/social_share/SocialSharePlugin.kt
+++ b/android/src/main/kotlin/com/shekarmudaliyar/social_share/SocialSharePlugin.kt
@@ -63,12 +63,12 @@ class SocialSharePlugin:FlutterPlugin, MethodCallHandler, ActivityAware {
                 intentString = "com.facebook.stories.ADD_TO_STORY"
             }
 
-            val stickerImage: String? = call.argument("stickerImage")
+            val stickerImagePath: String? = call.argument("stickerImagePath")
             val backgroundTopColor: String? = call.argument("backgroundTopColor")
             val backgroundBottomColor: String? = call.argument("backgroundBottomColor")
             val attributionURL: String? = call.argument("attributionURL")
-            val backgroundImage: String? = call.argument("backgroundImage")
-            val backgroundVideo: String? = call.argument("backgroundVideo")
+            val backgroundImagePath: String? = call.argument("backgroundImagePath")
+            val backgroundVideoPath: String? = call.argument("backgroundVideoPath")
 
             val appId: String? = call.argument("appId")
 
@@ -78,10 +78,10 @@ class SocialSharePlugin:FlutterPlugin, MethodCallHandler, ActivityAware {
             intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             
-            if (stickerImage!=null) {
-                val file =  File(activeContext!!.cacheDir,stickerImage)
-                val stickerImageFile = FileProvider.getUriForFile(activeContext!!, activeContext!!.applicationContext.packageName + ".com.shekarmudaliyar.social_share", file)
-                intent.putExtra("interactive_asset_uri", stickerImageFile)
+            if (stickerImagePath!=null) {
+                val file =  File(activeContext!!.cacheDir,stickerImagePath)
+                val stickerImage = FileProvider.getUriForFile(activeContext!!, activeContext!!.applicationContext.packageName + ".com.shekarmudaliyar.social_share", file)
+                intent.putExtra("interactive_asset_uri", stickerImage)
             }
 
             if (call.method == "shareFacebookStory") {
@@ -90,18 +90,18 @@ class SocialSharePlugin:FlutterPlugin, MethodCallHandler, ActivityAware {
                 intent.putExtra("source_application", appId)
             }
 
-            if (backgroundImage!=null) {
+            if (backgroundImagePath!=null) {
                 //check if background image is also provided
-                val backfile =  File(activeContext!!.cacheDir,backgroundImage)
-                val backgroundImageFile = FileProvider.getUriForFile(activeContext!!, activeContext!!.applicationContext.packageName + ".com.shekarmudaliyar.social_share", backfile)
-                intent.setDataAndType(backgroundImageFile,"image/*")
+                val backfile =  File(activeContext!!.cacheDir,backgroundImagePath)
+                val backgroundImage = FileProvider.getUriForFile(activeContext!!, activeContext!!.applicationContext.packageName + ".com.shekarmudaliyar.social_share", backfile)
+                intent.setDataAndType(backgroundImage,"image/*")
             }
 
-            if (backgroundVideo!=null) {
+            if (backgroundVideoPath!=null) {
                 //check if background video is also provided
-                val backfile =  File(activeContext!!.cacheDir,backgroundVideo)
-                val backgroundVideoFile = FileProvider.getUriForFile(activeContext!!, activeContext!!.applicationContext.packageName + ".com.shekarmudaliyar.social_share", backfile)
-                intent.setDataAndType(backgroundVideoFile,"video/*")
+                val backfile =  File(activeContext!!.cacheDir,backgroundVideoPath)
+                val backgroundVideo = FileProvider.getUriForFile(activeContext!!, activeContext!!.applicationContext.packageName + ".com.shekarmudaliyar.social_share", backfile)
+                intent.setDataAndType(backgroundVideo,"video/*")
             }
 
             intent.putExtra("content_url", attributionURL)

--- a/android/src/main/kotlin/com/shekarmudaliyar/social_share/SocialSharePlugin.kt
+++ b/android/src/main/kotlin/com/shekarmudaliyar/social_share/SocialSharePlugin.kt
@@ -70,8 +70,6 @@ class SocialSharePlugin:FlutterPlugin, MethodCallHandler, ActivityAware {
             val backgroundImage: String? = call.argument("backgroundImage")
             val backgroundVideo: String? = call.argument("backgroundVideo")
 
-            val file =  File(activeContext!!.cacheDir,stickerImage)
-            val stickerImageFile = FileProvider.getUriForFile(activeContext!!, activeContext!!.applicationContext.packageName + ".com.shekarmudaliyar.social_share", file)
             val appId: String? = call.argument("appId")
 
             val intent = Intent(intentString)
@@ -79,10 +77,17 @@ class SocialSharePlugin:FlutterPlugin, MethodCallHandler, ActivityAware {
             intent.type = "image/*"
             intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            intent.putExtra("interactive_asset_uri", stickerImageFile)
+            
+            if (stickerImage!=null) {
+                val file =  File(activeContext!!.cacheDir,stickerImage)
+                val stickerImageFile = FileProvider.getUriForFile(activeContext!!, activeContext!!.applicationContext.packageName + ".com.shekarmudaliyar.social_share", file)
+                intent.putExtra("interactive_asset_uri", stickerImageFile)
+            }
 
             if (call.method == "shareFacebookStory") {
                 intent.putExtra("com.facebook.platform.extra.APPLICATION_ID", appId)
+            } else {
+                intent.putExtra("source_application", appId)
             }
 
             if (backgroundImage!=null) {
@@ -99,7 +104,6 @@ class SocialSharePlugin:FlutterPlugin, MethodCallHandler, ActivityAware {
                 intent.setDataAndType(backgroundVideoFile,"video/*")
             }
 
-            intent.putExtra("source_application", appId)
             intent.putExtra("content_url", attributionURL)
             intent.putExtra("top_background_color", backgroundTopColor)
             intent.putExtra("bottom_background_color", backgroundBottomColor)

--- a/android/src/main/kotlin/com/shekarmudaliyar/social_share/SocialSharePlugin.kt
+++ b/android/src/main/kotlin/com/shekarmudaliyar/social_share/SocialSharePlugin.kt
@@ -87,8 +87,6 @@ class SocialSharePlugin:FlutterPlugin, MethodCallHandler, ActivityAware {
 
             if (call.method == "shareFacebookStory") {
                 intent.putExtra("com.facebook.platform.extra.APPLICATION_ID", appId)
-            } else {
-                intent.putExtra("source_application", appId)
             }
 
             if (backgroundImagePath!=null) {
@@ -105,6 +103,7 @@ class SocialSharePlugin:FlutterPlugin, MethodCallHandler, ActivityAware {
                 intent.setDataAndType(backgroundVideo,"video/*")
             }
 
+            intent.putExtra("source_application", appId)
             intent.putExtra("content_url", attributionURL)
             intent.putExtra("top_background_color", backgroundTopColor)
             intent.putExtra("bottom_background_color", backgroundBottomColor)

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -265,7 +265,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.3.1"
+    version: "2.3.2"
   source_span:
     dependency: transitive
     description:

--- a/ios/Classes/SocialSharePlugin.m
+++ b/ios/Classes/SocialSharePlugin.m
@@ -17,19 +17,17 @@
     if ([@"shareInstagramStory" isEqualToString:call.method] || [@"shareFacebookStory" isEqualToString:call.method]) {
 
         NSString *appID = call.arguments[@"appId"];
-
-        // Updated to reflect that Docs on Facebook/Instagram now show a different url scheme vs instagram, i.e FB does no longer take source_application queryParam
-        // FB Docs: https://developers.facebook.com/docs/sharing/sharing-to-stories/ios-developers
-        // Insta Docs: https://developers.facebook.com/docs/instagram/sharing-to-stories 
         NSString *destination;
-        NSURL *urlScheme;
+        NSString *stories;
         if ([@"shareInstagramStory" isEqualToString:call.method]) {
             destination = @"com.instagram.sharedSticker";
-            urlScheme = [NSURL URLWithString:[NSString stringWithFormat:@"instagram-stories://share?source_application=%@", appID]]; 
+            stories = @"instagram-stories";
         } else {
             destination = @"com.facebook.sharedSticker";
-            urlScheme = [NSURL URLWithString:@"facebook-stories://share"];
+            stories = @"facebook-stories";
         }
+
+        NSURL *urlScheme = [NSURL URLWithString:[NSString stringWithFormat:@"%@://share?source_application=%@", stories, appID]];
 
         NSString *stickerImagePath = call.arguments[@"stickerImagePath"];
         NSString *backgroundTopColor = call.arguments[@"backgroundTopColor"];

--- a/lib/social_share.dart
+++ b/lib/social_share.dart
@@ -9,7 +9,7 @@ class SocialShare {
 
   static Future<String?> shareInstagramStory({
     required String appId,
-    required String imagePath,
+    String? imagePath,
     String? backgroundTopColor,
     String? backgroundBottomColor,
     String? backgroundResourcePath,
@@ -69,7 +69,7 @@ class SocialShare {
     }
 
     Map<String, dynamic> args = <String, dynamic>{
-      "stickerImage": _imagePath,
+      "stickerImagePath": _imagePath,
       "backgroundTopColor": backgroundTopColor,
       "backgroundBottomColor": backgroundBottomColor,
       "attributionURL": attributionURL,
@@ -79,9 +79,9 @@ class SocialShare {
     if (_backgroundResourcePath != null) {
       var extension = _backgroundResourcePath.split(".").last;
       if (["png", "jpg", "jpeg"].contains(extension.toLowerCase())) {
-        args["backgroundImage"] = _backgroundResourcePath;
+        args["backgroundImagePath"] = _backgroundResourcePath;
       } else {
-        args["backgroundVideo"] = _backgroundResourcePath;
+        args["backgroundVideoPath"] = _backgroundResourcePath;
       }
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: social_share
 description: Wide variety of sharing options you'll need to share directly to certain well-known apps.
-version: 2.3.1
+version: 2.3.2
 homepage: https://github.com/ShekarMudaliyar/social_share
 
 environment:


### PR DESCRIPTION
Updated to reflect that Docs on Facebook/Instagram now show a different url scheme vs instagram, i.e FB does no longer take source_application queryParam, because it is included in the params as its own AppID key. So the AppID key should only be added if its FB, and the source_application param should only be added if it's Instagram.

Additionally, baked in functionality so that you don't _have_ to include a StickerImage, you can **just** include a background Image and it will now work, showing the image the full screen of Insta and/or FB.

iOS:
FB Docs: https://developers.facebook.com/docs/sharing/sharing-to-stories/ios-developers
Insta Docs: https://developers.facebook.com/docs/instagram/sharing-to-stories 

Android:
FB Docs: https://developers.facebook.com/docs/sharing/sharing-to-stories/android-developers
Insta Docs: https://developers.facebook.com/docs/instagram/sharing-to-stories 