### PR TITLE
Docs: delete deprecated methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,6 @@ SocialShare.shareInstagramStory(imageFile.path, "#ffffff",
                               "#000000", "https://deep-link-url");
 ```
 
-#### shareInstagramStorywithBackground
-
-```
- SocialShare.shareInstagramStorywithBackground(image.path, "https://deep-link-url",
-                              backgroundImagePath: backgroundimage.path);
-```
-
 #### shareFacebookStory
 
 For iOS


### PR DESCRIPTION
This PR deletes explanation of deprecated methods in `README.md`.

It seems to `shareInstagramStorywithBackground` was deprecated at #37, but document still wasn't updated.