### PR TITLE
add android namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,11 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 28
 
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.shekarmudaliyar.social_share'
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }


### PR DESCRIPTION
`flutter build appbundle` is returning

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':social_share'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.
```

details:

```
flutter version 3.19.2 
openjdk version "21.0.3" 2024-04-16
com.android.application version "8.3.2"
https://services.gradle.org/distributions/gradle-8.10-bin.zip
```